### PR TITLE
Add option --queryall

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Type `help` in interactive mode for more information.
 
 If you do not receive any replies, try using the `--bind` option to bind to a specific local interface.
 
-The program can also run in automatic mode if the `--query` switch is specified on the command line.
+The program can also run in automatic mode if the `--query` or '--queryall' switch is specified on the command line.
 The program has a number of switches - run `dhcptest --help` to see a list.
 
 An example command line to automatically send a discover packet and explicitly request option 43,

--- a/README.md
+++ b/README.md
@@ -18,13 +18,19 @@ Type `help` in interactive mode for more information.
 
 If you do not receive any replies, try using the `--bind` option to bind to a specific local interface.
 
-The program can also run in automatic mode if the `--query` or '--queryall' switch is specified on the command line.
+The program can also run in automatic mode if the `--query` switch is specified on the command line.
 The program has a number of switches - run `dhcptest --help` to see a list.
 
 An example command line to automatically send a discover packet and explicitly request option 43,
 wait for a reply, then print just that option:
 
     dhcptest --quiet --query --request 43 --print-only 43
+
+Query mode will report the first reply recieved. To automatically send a discover packet and wait for 
+all replies before the timeout, use --wait. For additional resilience against dropped packets on busy 
+networks, consider using the `--retry` and `--timeout` switches:
+
+    dhcptest --quiet --query --wait --retry 5 --timeout 10
 
 You can spoof the Vendor Class Identifier, or send additional DHCP options with the request packet,
 using the `--option` switch:
@@ -33,14 +39,16 @@ using the `--option` switch:
 
 See [RFC 2132](http://tools.ietf.org/html/rfc2132) for a list and description of DHCP options.
 
-For additional resilience against dropped packets on busy networks,
-consider using the `--retry` and `--timeout` switches.
 
 ## License
 
 `dhcptest` is available under the [Boost Software License 1.0](http://www.boost.org/LICENSE_1_0.txt).
 
 ## Changelog
+
+### dhcptest v0.6 (TBD)
+
+ * Add switch: `--wait`
 
 ### dhcptest v0.5 (2014-11-26)
 

--- a/dhcptest.d
+++ b/dhcptest.d
@@ -538,7 +538,7 @@ int main(string[] args)
 		"option", &sentOptions,
 	);
 
-	wait = query && wait;
+	if (wait) enforce(query, "Option --wait only supported with --query");
 	
 	/// https://issues.dlang.org/show_bug.cgi?id=6725
 	auto timeout = dur!"hnsecs"(cast(long)(convert!("seconds", "hnsecs")(1) * timeoutSeconds));

--- a/dhcptest.d
+++ b/dhcptest.d
@@ -518,7 +518,7 @@ int main(string[] args)
 {
 	string bindAddr = "0.0.0.0";
 	string defaultMac;
-	bool help, query;
+	bool help, query, queryall;
 	float timeoutSeconds = 0f;
 	uint tries = 1;
 
@@ -530,6 +530,7 @@ int main(string[] args)
 		"mac", &defaultMac,
 		"q|quiet", &quiet,
 		"query", &query,
+		"queryall", &queryall,
 		"request", &requestedOptions,
 		"print-only", &printOnly,
 		"timeout", &timeoutSeconds,
@@ -537,6 +538,8 @@ int main(string[] args)
 		"option", &sentOptions,
 	);
 
+	query = query || queryall;
+	
 	/// https://issues.dlang.org/show_bug.cgi?id=6725
 	auto timeout = dur!"hnsecs"(cast(long)(convert!("seconds", "hnsecs")(1) * timeoutSeconds));
 
@@ -561,6 +564,7 @@ int main(string[] args)
 		stderr.writeln("                  and error messages");
 		stderr.writeln("  --query         Instead of starting an interactive prompt, immediately send");
 		stderr.writeln("                  a discover packet, wait for a result, print it and exit.");
+		stderr.writeln("  --queryall      Same as --query, except all offers returned will be reported.");
 		stderr.writeln("  --option N=STR  Add a string option with code N and content STR to the");
 		stderr.writeln("                  request packet. E.g. to specify a Vendor Class Identifier:");
 		stderr.writeln("                  --option \"60=Initech Groupware\"");
@@ -678,21 +682,40 @@ int main(string[] args)
 		bindSocket();
 		auto sentPacket = generatePacket(parseMac(defaultMac));
 
+		int count = 0;
+		
 		foreach (t; 0..tries)
 		{
 			if (!quiet && t) stderr.writefln("Retrying, try %d...", t+1);
 
-			socket.sendPacket(sentPacket);
-			auto result = socket.receivePackets((DHCPPacket packet, Address address)
-			{
-				if (packet.header.xid != sentPacket.header.xid)
-					return true;
-				if (!quiet) stderr.writefln("Received packet from %s:", address);
-				stdout.printPacket(packet);
-				return false;
-			}, timeout);
+			SysTime start = Clock.currTime();
+			SysTime end = start + timeout;
 
-			if (result) // Got reply packet?
+			socket.sendPacket(sentPacket);
+			
+			while (true)
+			{
+				auto remaining = end - Clock.currTime();
+				if (remaining <= Duration.zero)
+					break;
+
+				auto result = socket.receivePackets((DHCPPacket packet, Address address)
+				{
+					if (packet.header.xid != sentPacket.header.xid)
+						return true;
+					if (!quiet) stderr.writefln("Received packet from %s:", address);
+					stdout.printPacket(packet);
+					return false;
+				}, remaining);
+
+				if (result && !queryall) // Got reply packet and do not wait for all query responses?
+					return 0;
+
+				if (result) // Got reply packet?
+					count++;
+			}
+
+			if (count) // Did we get any responses?
 				return 0;
 		}
 

--- a/dhcptest.d
+++ b/dhcptest.d
@@ -677,7 +677,7 @@ int main(string[] args)
 		if (tries == 0)
 			tries = tries.max;
 		if (timeout == Duration.zero)
-			timeout = tries == 1 ? forever : 10.seconds;
+			timeout = (tries == 1 && !queryall) ? forever : 10.seconds;
 
 		bindSocket();
 		auto sentPacket = generatePacket(parseMac(defaultMac));


### PR DESCRIPTION
Adding option --queryall which will print all DHCP responses until the timeout has elapsed instead of exiting after the first response is received. I created this modification to support performing on-demand DHCP tests and determining if multiple DHCP servers are active.