### PR TITLE
Allow formatted output for --print-only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ See [RFC 2132](http://tools.ietf.org/html/rfc2132) for a list and description of
 ### dhcptest v0.6 (TBD)
 
  * Add switch: `--wait`
+ * The --print-only option now understands output formatting:
+   `--print-only "N[hex]"` will output the value as a zero padded hexadecimal string of bytes.
+   `--print-only "N[ip]"` will output the value as an IP address.
 
 ### dhcptest v0.5 (2014-11-26)
 

--- a/dhcptest.d
+++ b/dhcptest.d
@@ -524,10 +524,7 @@ bool receivePackets(Socket socket, bool delegate(DHCPPacket, Address) handler, D
 				return true;
 		}
 		catch (Exception e)
-		{
 			stderr.writefln("Error while parsing packet [%(%02X %)]: %s", receivedData, e.toString());
-			end = Clock.currTime();
-		}
 	}
 
 	// timeout exceeded

--- a/dhcptest.d
+++ b/dhcptest.d
@@ -602,6 +602,8 @@ int main(string[] args)
 		stderr.writeln("                  Can be repeated several times to request multiple options.");
 		stderr.writeln("  --print-only N  Print only the specified DHCP option.");
 		stderr.writeln("                  It is assumed to be a text string.");
+		stderr.writeln("                  You can specify hexadecimal or IPv4-formatted output using");
+		stderr.writeln("                  --print-only \"N[hex]\" or --print-only \"N[IP]\"");
 		stderr.writeln("  --timeout N     Wait N seconds for a reply, after which retry or exit.");
 		stderr.writeln("                  Default is 10 seconds. Can be a fractional number. ");
 		stderr.writeln("  --tries N       Send N DHCP discover packets after each timeout interval.");


### PR DESCRIPTION
Modified to allow --print-only the same formatted output as normal
output. Use of print-only would treat all options as a string value,
which would not display an IP address, timestamp, or other number
correctly.