### PR TITLE
Additional DHCP options

### DIFF
--- a/dhcptest.d
+++ b/dhcptest.d
@@ -241,6 +241,7 @@ enum OptionFormat
 	relayAgent, // RFC 3046
 	vendorSpecificInformation,
 	classlessStaticRoute, // RFC 3442
+	clientIdentifier,
 	zerolength, // RFC 4039
 }
 
@@ -307,7 +308,7 @@ static this()
 		 49 : DHCPOptionSpec("X Window System Display Manager Option", OptionFormat.ip),
 		 50 : DHCPOptionSpec("Requested IP Address", OptionFormat.none),
 		 51 : DHCPOptionSpec("IP Address Lease Time", OptionFormat.time),
-		 52 : DHCPOptionSpec("Option Overload", OptionFormat.none),
+		 52 : DHCPOptionSpec("Option Overload", OptionFormat.clientIdentifier),
 		 53 : DHCPOptionSpec("DHCP Message Type", OptionFormat.dhcpMessageType),
 		 54 : DHCPOptionSpec("Server Identifier", OptionFormat.ip),
 		 55 : DHCPOptionSpec("Parameter Request List", OptionFormat.dhcpOptionType),
@@ -668,6 +669,10 @@ void printOption(File f, in ubyte[] bytes, OptionFormat fmt)
 			case OptionFormat.relayAgent:
 				f.writeln((const RelayAgentInformation(bytes)).toString());
 				break;
+			case OptionFormat.clientIdentifier:
+				enforce(bytes.length >= 1, "No type");
+				f.writefln("type=%d, clientIdentifier=%s", bytes[0], maybeAscii(bytes[1..$]));
+				break;
 			case OptionFormat.zerolength:
 				enforce(bytes.length==0, "Malformed Rapid Commit");
 				f.writeln();
@@ -687,6 +692,7 @@ void printRawOption(File f, in ubyte[] bytes, OptionFormat fmt)
 		case OptionFormat.hex:
 		case OptionFormat.relayAgent:
 		case OptionFormat.vendorSpecificInformation:
+		case OptionFormat.clientIdentifier:
 			f.writefln("%-(%02X%)", bytes);
 			break;
 		case OptionFormat.str:
@@ -904,6 +910,7 @@ DHCPPacket generatePacket(ubyte[] mac)
 				bytes = VendorSpecificInformation(value).toBytes().dup;
 				break;
 			case OptionFormat.classlessStaticRoute:
+			case OptionFormat.clientIdentifier:
 				throw new Exception(format("Sorry, the format %s is unsupported for parsing. Please specify another format explicitly.", fmt));
 			case OptionFormat.zerolength:
 				break;

--- a/dhcptest.d
+++ b/dhcptest.d
@@ -477,13 +477,13 @@ struct VLList(Type)
 			if (s[0].isDigit)
 			{
 				ubyte typeByte;
-				enforce(s.formattedRead!"%s"(&typeByte) == 1, "Expected relay agent sub-option type");
+				enforce(s.formattedRead!"%s"(&typeByte) == 1, "Expected sub-option type");
 				type = cast(Type)typeByte;
 			}
 			else
-				enforce(s.formattedRead!"%s"(&type) == 1, "Expected relay agent sub-option type");
+				enforce(s.formattedRead!"%s"(&type) == 1, "Expected sub-option type");
 
-			enforce(s.skipOver("="), "Expected = in relay agent sub-option");
+			enforce(s.skipOver("="), "Expected = in sub-option");
 			value = s.parseElement!(char[])();
 		}
 

--- a/dhcptest.d
+++ b/dhcptest.d
@@ -241,6 +241,7 @@ enum OptionFormat
 	relayAgent, // RFC 3046
 	vendorSpecificInformation,
 	classlessStaticRoute, // RFC 3442
+	zerolength, // RFC 4039
 }
 
 struct DHCPOptionSpec
@@ -329,8 +330,17 @@ static this()
 		 74 : DHCPOptionSpec("Default Internet Relay Chat (IRC) Server Option", OptionFormat.ip),
 		 75 : DHCPOptionSpec("StreetTalk Server Option", OptionFormat.ip),
 		 76 : DHCPOptionSpec("StreetTalk Directory Assistance (STDA) Server Option", OptionFormat.ip),
+		 80 : DHCPOptionSpec("Rapid Commit", OptionFormat.zerolength),
 		 82 : DHCPOptionSpec("Relay Agent Information", OptionFormat.relayAgent),
+		100 : DHCPOptionSpec("PCode", OptionFormat.str),
+		101 : DHCPOptionSpec("TCode", OptionFormat.str),
+		108 : DHCPOptionSpec("IPv6-Only Preferred", OptionFormat.u32),
+		114 : DHCPOptionSpec("DHCP Captive-Portal", OptionFormat.str),
+		116 : DHCPOptionSpec("Auto Config", OptionFormat.boolean),
+		118 : DHCPOptionSpec("Subnet Selection", OptionFormat.ip),
 		121 : DHCPOptionSpec("Classless Static Route Option", OptionFormat.classlessStaticRoute),
+		249 : DHCPOptionSpec("Microsoft Classless Static Route", OptionFormat.classlessStaticRoute),
+		252 : DHCPOptionSpec("Web Proxy Auto-Discovery", OptionFormat.str),
 		255 : DHCPOptionSpec("End Option", OptionFormat.none),
 	];
 }
@@ -658,6 +668,10 @@ void printOption(File f, in ubyte[] bytes, OptionFormat fmt)
 			case OptionFormat.relayAgent:
 				f.writeln((const RelayAgentInformation(bytes)).toString());
 				break;
+			case OptionFormat.zerolength:
+				enforce(bytes.length==0, "Malformed Rapid Commit");
+				f.writeln();
+				break;
 		}
 	catch (Exception e)
 		f.writefln("Decode error (%s). Raw bytes: %s",
@@ -691,6 +705,7 @@ void printRawOption(File f, in ubyte[] bytes, OptionFormat fmt)
 			return printOption(f, bytes, fmt);
 		case OptionFormat.time:
 			return printOption(f, bytes, OptionFormat.u32);
+		case OptionFormat.zerolength:
 	}
 }
 
@@ -890,6 +905,8 @@ DHCPPacket generatePacket(ubyte[] mac)
 				break;
 			case OptionFormat.classlessStaticRoute:
 				throw new Exception(format("Sorry, the format %s is unsupported for parsing. Please specify another format explicitly.", fmt));
+			case OptionFormat.zerolength:
+				break;
 		}
 		packet.options ~= DHCPOption(opt, bytes);
 	}


### PR DESCRIPTION
This commit adds support for the following dhcp options:

DHCP option 80, Rapid Commit - RFC4039
DHCP options 100 & 101, time zone - RFC4833
DHCP option 108, IPv6-Only perferred - RFC892
DHCP option 114, DHCP Captive Portal - RFC8910
DHCP option 116, DHCP-Auto configure - RFC2563
DHCP option 118, Subnet selection - RFC3011
DHCP option 249, Microsoft classless static route - MS-DHCPE
	( https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dhcpe )
DHCP option 252, Web Proxy Auto-Discovery - ietf draft
	( https://tools.ietf.org/html/draft-ietf-wrec-wpad-01 )