### PR TITLE
Swap 'special' and 'unknown' in enum, so that 'unknown' is default

### DIFF
--- a/dhcptest.d
+++ b/dhcptest.d
@@ -224,8 +224,8 @@ enum NETBIOSNodeTypeChars = "BPMH";
 /// How option values are displayed and interpreted
 enum OptionFormat
 {
-	special,
 	unknown,
+	special,
 	str,
 	ip,
 	IP = ip, // for backwards compatibility


### PR DESCRIPTION
If 'special' is the default for unknown options then dhcptest refuses to accept them, with 'Fatal error: Can't specify a value for special option NN' when there is no format specifed, or with an assertion at line 616 for basically the same reason, if there is a format specifier.

Swapping so that 'unknown' is the default means that unknown options can be successfully manually specified.